### PR TITLE
fix(isolate): add rest parameter to and rename `scopedDialogue`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "MIT",
   "homepage": "https://cyclejs.github.io",
   "bugs": "https://github.com/cyclejs/isolate/issues",
+  "contributors": [{
+    "name": "Frederik Krautwald"
+  }],
   "repository": {
     "type": "git",
     "url": "https://github.com/cyclejs/isolate"

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ function isolate(dataflowComponent, scope = newScope()) {
     throw new Error(`Second argument given to isolate() must be a ` +
       `string for 'scope'`)
   }
-  return function scopedDialogue(sources) {
+  return function scopedDataflowComponent(sources, ...rest) {
     const scopedSources = {}
     for (let key in sources) {
       if (sources.hasOwnProperty(key) &&
@@ -52,7 +52,7 @@ function isolate(dataflowComponent, scope = newScope()) {
         scopedSources[key] = sources[key]
       }
     }
-    const sinks = dataflowComponent(scopedSources)
+    const sinks = dataflowComponent(scopedSources, ...rest)
     const scopedSinks = {}
     for (let key in sinks) {
       if (sinks.hasOwnProperty(key) &&

--- a/test/index.js
+++ b/test/index.js
@@ -42,17 +42,17 @@ describe('isolate', function () {
         return {};
       }
 
-      function MyDataflowComponent(sources) {
+      function MyDataflowComponent(sources, foo, bar) {
         return {
-          other: Rx.Observable.just('a')
+          other: Rx.Observable.just([foo, bar])
         };
       }
       const scopedMyDataflowComponent = isolate(MyDataflowComponent);
-      const scopedSinks = scopedMyDataflowComponent({other: driver()});
+      const scopedSinks = scopedMyDataflowComponent({other: driver()}, `foo`, `bar`);
 
       assert.strictEqual(typeof scopedSinks, `object`);
       scopedSinks.other.subscribe(x => {
-        assert.strictEqual(x, 'a');
+        assert.strictEqual(x.join(), `foo,bar`);
       })
     })
 


### PR DESCRIPTION
Rename `scopedDialogue` to `scopedDataflowComponent`.
Update test.

**Before:**

``` js
function Dfc(sources, foo, bar) { return {foo, bar }  }

var dfc = isolate(Dfc)

var obj = dfc(sources, `foo`, `bar`); // Uncaught ReferenceError: foo is not defined
```

The returned function from `isolate` only accepts `sources`.

**After:**

``` js
function Dfc(sources, foo, bar) { return {foo, bar }  }

var dfc = isolate(Dfc)

var obj = dfc(sources, `foo`, `bar`);

console.log(obj); // Object {foo: "foo", bar: "bar"}
```

The returned function from `isolate` accepts all arguments.

Closes #2
