### PR TITLE
[WIP] Allow restarting autoScope counter with isolate.reset()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,4 +70,6 @@ function isolate(dataflowComponent, scope = newScope()) {
   }
 }
 
+isolate.reset = () => counter = 0
+
 module.exports = isolate


### PR DESCRIPTION
In order to hot reload code, we need to get the same results from isolate each time we run the main function. To do that, cycle-restart needs to be able to reset the counter.
