### PR TITLE
safeguard against driver with no source

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ function isolate(dataflowComponent, scope = newScope()) {
   return function scopedDataflowComponent(sources, ...rest) {
     const scopedSources = {}
     for (let key in sources) {
-      if (sources.hasOwnProperty(key) &&
+      if (sources.hasOwnProperty(key) && sources[key] &&
         typeof sources[key].isolateSource === `function`)
       {
         scopedSources[key] = sources[key].isolateSource(sources[key], scope)

--- a/test/index.js
+++ b/test/index.js
@@ -108,5 +108,11 @@ describe('isolate', function () {
       assert.strictEqual(scopedSinks.other.length, 1);
       assert.strictEqual(scopedSinks.other[0], `a myScope`);
     });
+
+    it('should handle driver with no source without failing', function () {
+      const MyDataflowComponent = ()=> ({});
+      const scopedMyDataflowComponent = isolate(MyDataflowComponent, `myScope`);
+      assert.doesNotThrow(()=> scopedMyDataflowComponent({noSource:undefined}))
+    });
   });
 });


### PR DESCRIPTION
Right now isolated component won't work if we use drivers with no sources, like the simple log driver from the [CycleJS driver page](http://cycle.js.org/drivers.html):

```
const logDriver = msg$ => { msg$.subscribe(msg => console.log(msg)) }
```

For a live demo check out [this webpackbin](http://www.webpackbin.com/4keq7pQ-Z).

This PR adds a guard to make sure that the source prop isn't undefined, which will be the case with the above driver.
