### PR TITLE
Include LabeledSlider Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We use only one repository for issues. [**Open the issue at Cycle Core repo.**](
 
 ```js
 import isolate from '@cycle/isolate';
+import LabeledSlider from './LabeledSlider';
 
 function bmiCalculator({DOM}) {
   let weightProps$ = Rx.Observable.just({


### PR DESCRIPTION
Explicitly show the source of the variable `LabeledSlider` to help demonstrate the functionality of `isolate`.
